### PR TITLE
clean through Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,4 +72,4 @@ obj/%.o: %.S
 	@arm-none-eabi-gcc $(ASM_FLAGS) $(INCLUDES) $(DEFINES) $(WIFI) -x assembler-with-cpp -c $< -o $@
 
 clean:
-	@rm -rf obj firmware.elf firmware.uf2
+	$(DOCKER) rm -rf obj firmware.elf firmware.uf2


### PR DESCRIPTION
In some systems, as Docker runs as root, the end user does not own the generated files and can't rm them